### PR TITLE
DEV-838 - Rename and expand institution admin permissions

### DIFF
--- a/app/template.ejs
+++ b/app/template.ejs
@@ -100,7 +100,7 @@
             <li class="hidden-xs">
               <a>{{eventGroup.timezone}}</a>
             </li>
-            <li ng-show="!templateCtrl.hasInstitution || user.isRootAdmin()" class="hidden-xs">
+            <li ng-show="!templateCtrl.hasInstitution || user.isInstitutionAdmin()" class="hidden-xs">
               <a>
                 <select style="width:300px;color:inherit;background-color:inherit;border:none" ng-model="templateCtrl.selectInstitution" ng-options="o for o in templateCtrl.institutions track by o"  ng-change="templateCtrl.institutionChange(templateCtrl.selectInstitution)">
                 </select>

--- a/app/template.js
+++ b/app/template.js
@@ -47,7 +47,7 @@ define(['app',
             };
             $rootScope.user.isInstitutionAdmin = function() {
 
-                return _.intersection($rootScope.user.roles, ['Administrator', 'EunoIntitutionSwitch']).length > 0
+                return _.intersection($rootScope.user.roles, ['Administrator', 'EunoInstitutionSwitch']).length > 0
             };
 
             _ctrl.isAdmin=$rootScope.user.isAdmin;

--- a/app/template.js
+++ b/app/template.js
@@ -43,11 +43,11 @@ define(['app',
             
             $rootScope.user.isAdmin = function() {
 
-                return _.intersection($rootScope.user.roles, [ 'EunoAdministrator']).length > 0;
+                return _.intersection($rootScope.user.roles, ['EunoAdministrator']).length > 0
             };
-            $rootScope.user.isRootAdmin = function() {
+            $rootScope.user.isInstitutionAdmin = function() {
 
-                return _.intersection($rootScope.user.roles, [ 'Administrator']).length > 0;
+                return _.intersection($rootScope.user.roles, ['Administrator', 'EunoIntitutionSwitch']).length > 0
             };
 
             _ctrl.isAdmin=$rootScope.user.isAdmin;


### PR DESCRIPTION
Renames the `isRootAdmin` check to `isInstitutionAdmin` and adds the `EunoIntitutionSwitch` role to the authorized list, allowing more users to access the institution selector.
